### PR TITLE
Bug/client tool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ npm install -g @cleanunicorn/mythos
 $ mythos COMMAND
 running command...
 $ mythos (-v|--version|version)
-@cleanunicorn/mythos/0.1.1 linux-x64 node-v11.10.0
+@cleanunicorn/mythos/0.1.2 linux-x64 node-v11.10.0
 $ mythos --help [COMMAND]
 USAGE
   $ mythos COMMAND
@@ -109,7 +109,7 @@ OPTIONS
   --timeout=timeout                  [default: 180] How many seconds to wait for the result
 ```
 
-_See code: [src/commands/analyze.ts](https://github.com/cleanunicorn/mythos/blob/v0.1.1/src/commands/analyze.ts)_
+_See code: [src/commands/analyze.ts](https://github.com/cleanunicorn/mythos/blob/v0.1.2/src/commands/analyze.ts)_
 
 ## `mythos help [COMMAND]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleanunicorn/mythos",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cleanunicorn/mythos",
   "description": "A CLI client for MythX",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Daniel Luca @cleanunicorn",
   "bin": {
     "mythos": "./bin/run"

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -20,7 +20,6 @@ module.exports.Scanner = class Scanner {
     const contractSource = fs.readFileSync(contractFile, { encoding: 'utf-8' })
 
     const data = {
-      clientToolName: "mythos",
       contractName: contractName,
       abi: contractData['abi'],
       //
@@ -44,6 +43,7 @@ module.exports.Scanner = class Scanner {
       this.client.analyze({
         data,
         timeout,
+        clientToolName: "mythos",
       }).then(issues => {
         fs.writeFileSync('./issues.json', JSON.stringify(issues, null, 4), 'utf-8');
         resolve(issues);


### PR DESCRIPTION
Correctly send `clientToolName` when requesting audits